### PR TITLE
Create todo app for daily routine 

### DIFF
--- a/src/DailyRoutineList.jsx
+++ b/src/DailyRoutineList.jsx
@@ -1,8 +1,13 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
 
 import Item from './Item';
 
-export default function DailyRoutineList({ tasks, onClickDelete }) {
+export default function DailyRoutineList({ handleClickDelete }) {
+  const { tasks } = useSelector((state) => ({
+    tasks: state.tasks,
+  }));
+
   if (tasks.length === 0) {
     return (
       <p>Add your routine</p>
@@ -12,7 +17,7 @@ export default function DailyRoutineList({ tasks, onClickDelete }) {
   return (
     <ol>
       {tasks.map((task) => (
-        <Item key={task.id} task={task} onClickDelete={onClickDelete} />
+        <Item key={task.id} task={task} onClickDelete={handleClickDelete} />
       ))}
     </ol>
   );

--- a/src/Form.jsx
+++ b/src/Form.jsx
@@ -1,11 +1,39 @@
-import React from 'react';
+import React, { useState } from 'react';
+
+import { useDispatch, useSelector } from 'react-redux';
 
 import Fab from '@material-ui/core/Button';
 import AddIcon from '@material-ui/icons/Add';
 
-export default function Form({ value, onChange, onClick }) {
+import {
+  addTask,
+  updateTaskTitle,
+} from './action';
+
+export default function Form() {
+  const { taskTitle } = useSelector((state) => ({
+    taskTitle: state.taskTitle,
+  }));
+
+  const dispatch = useDispatch();
+
+  const [task, setTask] = useState('');
+
+  const handleChange = (event) => {
+    console.log('event', event.target.value);
+    setTask(event.target.value);
+    dispatch(updateTaskTitle(event.target.value));
+  };
+
+  const handleSubmit = (event) => {
+    console.log(task);
+    // TODO: update taks list store
+    event.preventDefault();
+    dispatch(addTask());
+  };
+
   return (
-    <p>
+    <form onSubmit={handleSubmit}>
       <h1>
         <label htmlFor="input-task-title">
           Make your routine
@@ -15,12 +43,12 @@ export default function Form({ value, onChange, onClick }) {
         id="input-task-title"
         type="text"
         placeholder="Write your routine"
-        value={value}
-        onChange={onChange}
+        value={taskTitle}
+        onChange={handleChange}
       />
-      <Fab color="primary" aria-label="add" onClick={onClick}>
+      <Fab role="button" color="primary" aria-label="add" type="submit" value="Submit">
         <AddIcon />
       </Fab>
-    </p>
+    </form>
   );
 }

--- a/src/Form.jsx
+++ b/src/Form.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -10,6 +10,8 @@ import {
   updateTaskTitle,
 } from './action';
 
+import DailyRoutineList from './DailyRoutineList';
+
 export default function Form() {
   const { taskTitle } = useSelector((state) => ({
     taskTitle: state.taskTitle,
@@ -17,38 +19,35 @@ export default function Form() {
 
   const dispatch = useDispatch();
 
-  const [task, setTask] = useState('');
-
   const handleChange = (event) => {
-    console.log('event', event.target.value);
-    setTask(event.target.value);
     dispatch(updateTaskTitle(event.target.value));
   };
 
   const handleSubmit = (event) => {
-    console.log(task);
-    // TODO: update taks list store
-    event.preventDefault();
     dispatch(addTask());
+    event.preventDefault();
   };
 
   return (
-    <form onSubmit={handleSubmit}>
-      <h1>
-        <label htmlFor="input-task-title">
-          Make your routine
-        </label>
-      </h1>
-      <input
-        id="input-task-title"
-        type="text"
-        placeholder="Write your routine"
-        value={taskTitle}
-        onChange={handleChange}
-      />
-      <Fab role="button" color="primary" aria-label="add" type="submit" value="Submit">
-        <AddIcon />
-      </Fab>
-    </form>
+    <>
+      <form onSubmit={handleSubmit}>
+        <h1>
+          <label htmlFor="input-task-title">
+            Make your routine
+          </label>
+        </h1>
+        <input
+          id="input-task-title"
+          type="text"
+          placeholder="Write your routine"
+          value={taskTitle}
+          onChange={handleChange}
+        />
+        <Fab role="button" color="primary" aria-label="add" type="submit" value="Submit">
+          <AddIcon />
+        </Fab>
+      </form>
+      <DailyRoutineList />
+    </>
   );
 }

--- a/src/Item.jsx
+++ b/src/Item.jsx
@@ -1,10 +1,25 @@
 import React from 'react';
 
-export default function Item({ task: { id, title }, onClickDelete }) {
+import { useDispatch } from 'react-redux';
+
+import {
+  deleteTask,
+} from './action';
+
+export default function Item({ task }) {
+  const dispatch = useDispatch();
+
+  const handleClickDelete = () => {
+    dispatch(deleteTask(task.id));
+  };
+
   return (
     <li>
-      {title}
-      <button type="button" onClick={() => onClickDelete(id)}>
+      {task.title}
+      <button
+        type="button"
+        onClick={() => handleClickDelete(task.id)}
+      >
         Done
       </button>
     </li>

--- a/src/action.js
+++ b/src/action.js
@@ -1,0 +1,14 @@
+export function addTask() {
+  return {
+    type: 'addTask',
+  };
+}
+
+export function updateTaskTitle(taskTitle) {
+  return {
+    type: 'updateTaskTitle',
+    payload: {
+      taskTitle,
+    },
+  };
+}

--- a/src/action.js
+++ b/src/action.js
@@ -12,3 +12,12 @@ export function updateTaskTitle(taskTitle) {
     },
   };
 }
+
+export function deleteTask(id) {
+  return {
+    type: 'deleteTask',
+    payload: {
+      id,
+    },
+  };
+}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,16 +1,18 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import {
-  BrowserRouter,
-} from 'react-router-dom';
+import { Provider } from 'react-redux';
+import { BrowserRouter } from 'react-router-dom';
 
 import App from './App';
+import store from './store';
 
 ReactDOM.render(
   (
     <BrowserRouter>
-      <App />
+      <Provider store={store}>
+        <App />
+      </Provider>
     </BrowserRouter>
   ),
   document.getElementById('app'),

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -1,0 +1,31 @@
+const initialState = {
+  newId: 100,
+  taskTitle: '',
+  tasks: [],
+};
+
+export default function reducer(state = initialState, action) {
+  const { newId, taskTitle, tasks } = state;
+
+  if (action.type === 'addTask') {
+    if (!taskTitle) {
+      return state;
+    }
+
+    return {
+      ...state,
+      newId: newId + 1,
+      taskTitle: '',
+      tasks: [...tasks, { id: newId, title: taskTitle }],
+    };
+  }
+
+  if (action.type === 'updateTaskTitle') {
+    return {
+      ...state,
+      taskTitle: action.payload.taskTitle,
+    };
+  }
+
+  return state;
+}

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -27,5 +27,12 @@ export default function reducer(state = initialState, action) {
     };
   }
 
+  if (action.type === 'deleteTask') {
+    return {
+      ...state,
+      tasks: tasks.filter((task) => task.id !== action.payload.id),
+    };
+  }
+
   return state;
 }

--- a/src/store.js
+++ b/src/store.js
@@ -1,0 +1,7 @@
+import { createStore } from 'redux';
+
+import reducer from './reducer';
+
+const store = createStore(reducer);
+
+export default store;


### PR DESCRIPTION
현재 Daily Routine 버튼 클릭 시 TODO를 작성하도록 되어있다.
그런데 TODO 작성 시 ADD 버튼을 클릭하면 내용이 추가가 되지 않는다.
그래서 ADD 버튼을 누르면 할 일 목록들이 화면에 그려지고 그것들을 관리 할 수 있도록 해야한다.

 

- [x] ADD 버튼을 클릭 시 TODO 리스트에 추가
- [x]  TODO List 관리 : 완성된 할 일은 done 버튼을 누르면 삭제된다.